### PR TITLE
Randomize UNSC quadratic voting transcript corpus

### DIFF
--- a/mechanism_design/README.md
+++ b/mechanism_design/README.md
@@ -1,233 +1,50 @@
-# Mechanism Design - Auction and Voting Systems
+# Mechanism Design Lab
 
-This folder contains all mechanism design proposals, including auction formats, voting rules, and institutional innovations.
+The mechanism design folder curates experiments, theoretical notes, and simulation artefacts that examine how institutions shape collective outcomes. It combines auction theory write-ups, voting rule prototypes, and United Nations Security Council (UNSC) quadratic-voting transcripts used for the Week 6 reflection exercise.
 
-## Contents
+## Repository Guide
 
-### Auction Mechanisms
-- First-price sealed-bid auctions
-- Second-price (Vickrey) auctions
-- Common-value auctions
-- Budgeted bidding mechanisms
-- Winner's curse analysis
+| Folder | Purpose |
+| --- | --- |
+| `auctions/` | Comparative analyses of first-price, Vickrey, and common-value environments, including budget-aware extensions. |
+| `voting/` | Classical and novel voting-rule briefs together with strategy notes and impossibility results. |
+| `implementations/` | Python utilities that simulate auction and voting dynamics for rapid experimentation. |
+| `case_studies/` | Field observations, Nobel insights, and applied mechanism case files that inform the broader research narrative. |
+| `llm_transcripts.md` | Randomized UNSC transcripts demonstrating quadratic voting with veto credits. |
 
-### Voting Mechanisms
-- Classical voting rules (plurality, Borda, approval)
-- Strategic voting analysis
-- Impossibility theorems (Arrow, Gibbard-Satterthwaite)
-- Novel voting mechanisms
-- Blockchain-based governance
+## Quadratic Voting Transcript Collection
 
-### Institutional Design
-- Market design applications
-- Matching mechanisms (Shapley-Roth)
-- Incentive compatibility analysis
-- Revenue equivalence theorems
+The Week 6 reflection required drafting synthetic LLM conversations that mimic UNSC delegates allocating quadratic veto credits. The refreshed transcript set now includes 75 conversations organised into five thematic rounds (`Transcript 1-1` through `Transcript 5-15`). Each transcript obeys the following design rules:
 
-## File Structure
+- **Credit endowments** cycle through {0, 1, 4, 9}, with only three delegates wielding 9 credits across the entire dataset.
+- **System prompt sections** are shuffled every time, randomising the order in which the delegate learns about their role, the voting agenda, the credit budget, the quadratic cost reminder, and the available action menu.
+- **Action menus** present the five possible decisions — `Approve (for sure)`, `Approve (possible abstention)`, `Abstention`, `Decline (Possible Abstention)`, and `Decline` — in a unique permutation for each transcript.
+- **Delegate responses** reference one of the five options while articulating how veto credits are spent or withheld and why the thematic focus demands additional safeguards.
 
-```
-mechanism_design/
-├── auctions/
-│   ├── first_price_auction.md          # First-price auction analysis
-│   ├── vickrey_auction.md              # Second-price auction design
-│   ├── common_value_auction.md         # Common-value auction experiments
-│   ├── budgeted_mechanism.md           # Budgeted bidding innovation
-│   └── winners_curse_analysis.md       # Winner's curse documentation
-├── voting/
-│   ├── classical_rules.md              # Traditional voting systems
-│   ├── strategic_voting.md             # Strategic manipulation analysis
-│   ├── novel_mechanisms.md             # Innovative voting proposals
-│   └── blockchain_governance.md        # Decentralized voting systems
-├── implementations/
-│   ├── auction_simulator.py            # Auction simulation code
-│   ├── voting_system.py                # Voting mechanism implementation
-│   └── mechanism_evaluator.py          # Evaluation framework
-├── case_studies/
-│   ├── field_trip_inspiration.md       # Real-world mechanism observations
-│   ├── nobel_insights.md               # Lessons from Nobel laureates
-│   └── practical_applications.md       # Implementation considerations
-└── README.md                            # This file
-```
+### Round-level Summary
 
-## Auction Design
+| Round | Theme | Credit Mix | Decision Mix |
+| --- | --- | --- | --- |
+| 1 | Humanitarian Corridors | 0×4 · 1×6 · 4×4 · 9×1 | Decline×2 · Decline (Possible Abstention)×3 · Abstention×3 · Approve (possible abstention)×3 · Approve (for sure)×4 |
+| 2 | Ceasefire Oversight | 0×4 · 1×6 · 4×5 | Decline×3 · Decline (Possible Abstention)×2 · Abstention×4 · Approve (possible abstention)×4 · Approve (for sure)×2 |
+| 3 | Reconstruction Mandate | 0×5 · 1×3 · 4×6 · 9×1 | Decline×2 · Decline (Possible Abstention)×4 · Abstention×4 · Approve (possible abstention)×2 · Approve (for sure)×3 |
+| 4 | Sanctions Review | 0×4 · 1×5 · 4×6 | Decline×3 · Decline (Possible Abstention)×3 · Abstention×3 · Approve (possible abstention)×5 · Approve (for sure)×1 |
+| 5 | Peacekeeping Logistics | 0×7 · 1×2 · 4×5 · 9×1 | Decline×3 · Decline (Possible Abstention)×4 · Abstention×2 · Approve (possible abstention)×1 · Approve (for sure)×5 |
 
-### Problem Set 2 Context
-Building on PS2 from the budgeted-vickrey repository, we analyze:
-- How bidders behave in different auction formats
-- The winner's curse in common-value auctions
-- Bounded rationality and overbidding
-- Mechanism design for budget constraints
+Use these aggregates to trace how the distribution of options changes from round to round, satisfying the requirement that every round presents a distinct decision spread.
 
-### Auction Formats Analyzed
+### Working with the Transcripts
 
-#### 1. First-Price Sealed-Bid Auction
-- **Rules**: Highest bidder wins, pays their bid
-- **Strategy**: Bid shading below valuation
-- **Properties**: Not truthful, revenue considerations
+1. **Qualitative comparison** – Select a round and compare how delegates with identical credits diverge in their responses depending on the action menu order.
+2. **Quantitative coding** – Label each transcript by option choice and veto expenditure to feed into subsequent behavioural or computational analyses.
+3. **Prompt engineering** – Reuse the shuffled system prompts to seed new LLM experiments; the randomised sections make it easy to test sensitivity to instruction ordering.
 
-#### 2. Second-Price (Vickrey) Auction
-- **Rules**: Highest bidder wins, pays second-highest bid
-- **Strategy**: Truthful bidding is dominant
-- **Properties**: Incentive compatible, revenue equivalence
+All transcripts live in [`llm_transcripts.md`](llm_transcripts.md). The file is self-contained so that instructors and classmates can copy transcripts directly into reflection documents without additional scripting.
 
-#### 3. Common-Value Auction
-- **Rules**: Item has same value to all, but unknown
-- **Challenge**: Winner's curse - winners systematically overpay
-- **Mitigation**: Bayesian updating, conservative bidding
+## Future Directions
 
-#### 4. Budgeted Mechanisms
-- **Constraint**: Bidders have limited budgets
-- **Innovation**: Mechanism design with budget feasibility
-- **Applications**: Ad auctions, resource allocation
+- Expand beyond the UNSC template to include other international decision bodies using the same quadratic-voting scaffold.
+- Develop automated notebooks that recompute transcript statistics and visualise credit allocations as Sankey or chord diagrams.
+- Integrate behavioural-science notes from the field trip with the synthetic transcripts to triangulate insights about strategic abstention and coalition bargaining.
 
-### Experimental Design
-
-1. **Theoretical Predictions**: Compute equilibrium bidding strategies
-2. **Human Experiments**: Test with classmates in oTree
-3. **AI Experiments**: Compare LLM bidding to human behavior
-4. **Analysis**: Identify deviations, bounded rationality patterns
-
-## Voting Mechanism Design
-
-### Nobel Insights Integration
-
-#### Arrow's Impossibility Theorem
-- No voting system can satisfy all desirable properties simultaneously
-- Trade-offs in democratic design
-
-#### Buchanan on Institutions
-- Rules and constraints shape collective outcomes
-- Constitutional design considerations
-
-#### Hurwicz-Maskin-Myerson on Mechanism Design
-- Incentive compatibility
-- Implementation theory
-- Revelation principle
-
-#### Shapley-Roth on Matching
-- Stable matching algorithms
-- Deferred acceptance mechanism
-- Applications to school choice, organ donation
-
-#### Acemoglu-Johnson-Robinson on Institutions
-- Political institutions and economic outcomes
-- Legitimacy and inclusiveness
-
-### Voting Rules Analyzed
-
-#### Classical Rules
-1. **Plurality**: Most votes wins (strategic voting issues)
-2. **Borda Count**: Ranked preferences, points-based
-3. **Approval Voting**: Approve any number of candidates
-4. **Condorcet Methods**: Pairwise majority comparisons
-
-#### Novel Mechanisms
-1. **Quadratic Voting**: Intensity of preferences through cost function
-2. **Liquid Democracy**: Delegative voting with transitive proxies
-3. **Blockchain Governance**: Decentralized, transparent voting
-4. **AI-Assisted Aggregation**: Machine learning for preference learning
-
-### Field Trip Inspiration
-
-Drawing from the field trip to innovation hubs, we explore:
-- Real-world governance challenges (UN climate negotiations, DAO governance)
-- Blockchain-based voting in decentralized organizations
-- Algorithmic matching in markets
-- Sustainable mechanism design
-
-## Implementation and Evaluation
-
-### Simulation Framework
-
-```python
-from implementations.auction_simulator import AuctionSimulator
-from implementations.voting_system import VotingMechanism
-
-# Auction simulation
-auction = AuctionSimulator(auction_type="vickrey", num_bidders=5)
-results = auction.run(valuations=[10, 20, 30, 40, 50])
-
-# Voting simulation
-voting = VotingMechanism(rule="borda")
-outcome = voting.aggregate_preferences(ballots)
-```
-
-### Evaluation Criteria
-
-#### Auction Mechanisms
-- **Efficiency**: Does highest-value bidder win?
-- **Revenue**: How much revenue does seller generate?
-- **Incentive Compatibility**: Is truthful bidding optimal?
-- **Fairness**: Do all bidders have equal opportunity?
-
-#### Voting Mechanisms
-- **Pareto Efficiency**: No Pareto improvements possible?
-- **Strategy-Proofness**: Is truthful voting optimal?
-- **Anonymity**: Do voter identities not matter?
-- **Monotonicity**: More support never hurts a candidate?
-
-## Case Studies
-
-### 1. Budgeted Vickrey Auction
-- Extend Vickrey auction to budget-constrained bidders
-- Analyze equilibrium with budget constraints
-- Compare to standard Vickrey outcomes
-
-### 2. Blockchain-Based Voting
-- Design transparent, tamper-proof voting mechanism
-- Use smart contracts for vote tallying
-- Ensure privacy and verifiability
-
-### 3. Climate Agreement Mechanism
-- Inspired by field trip observations
-- Design mechanism for international cooperation
-- Balance sovereignty with collective action
-
-## Integration with Other Components
-
-- **Economist**: Theoretical foundations for mechanisms
-- **Computational Scientist**: Implementation and simulation
-- **Behavioral Scientist**: Experimental validation
-- **Visualizations**: Mechanism performance charts
-
-## Key Results
-
-### Auction Analysis
-- Comparison of revenue across formats
-- Evidence of winner's curse
-- Effectiveness of budget constraints
-
-### Voting Analysis
-- Susceptibility to strategic manipulation
-- Trade-offs between different criteria
-- Performance of novel mechanisms
-
-### Mechanism Innovations
-- Proposed improvements to existing mechanisms
-- New hybrid approaches
-- Real-world applicability
-
-## Tools and References
-
-### Implementation
-- **Python**: Simulation and analysis
-- **Solidity**: Smart contracts (for blockchain voting)
-- **oTree**: Experimental implementation
-
-### Theoretical Resources
-- Myerson (1981): Optimal Auction Design
-- Maskin & Tirole (1990): Implementation Theory
-- Roth (2008): Deferred Acceptance Algorithm
-
-### Field Applications
-- FCC Spectrum Auctions
-- Google Ad Auctions
-- School Choice Mechanisms
-- Kidney Exchange Networks
-
----
-
-*For theoretical analysis, see [`../economist/`](../economist/)*  
-*For computational tools, see [`../computational_scientist/`](../computational_scientist/)*  
-*For experimental validation, see [`../behavioral_scientist/`](../behavioral_scientist/)*
+By reorganising the README and regenerating the transcript corpus, the mechanism design module now offers a reproducible foundation for studying institutional choice under quadratic voting.

--- a/mechanism_design/llm_transcripts.md
+++ b/mechanism_design/llm_transcripts.md
@@ -1,0 +1,453 @@
+# Quadratic Voting with Veto Credits – LLM Transcripts
+
+These transcripts randomize both the system instructions and the voting options to explore how veto-credit endowments shape Security Council behavior across five thematic rounds.
+
+### Transcript 1-1 – United States – Humanitarian Corridors (9 credits)
+SYSTEM: Your action menu contains: Abstention, Decline (Possible Abstention), Approve (for sure), Decline, Approve (possible abstention). You possess 9 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', United States declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the humanitarian corridors provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 1-2 – United Kingdom – Humanitarian Corridors (1 credit)
+SYSTEM: Your action menu contains: Approve (possible abstention), Decline, Approve (for sure), Abstention, Decline (Possible Abstention). You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', United Kingdom declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the humanitarian corridors provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 1-3 – France – Humanitarian Corridors (0 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Decline (Possible Abstention), Decline, Approve (for sure), Approve (possible abstention), Abstention. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', France chooses to abstain, holding veto credits in reserve. The delegation explains that the humanitarian corridors provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 1-4 – Russian Federation – Humanitarian Corridors (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline, Approve (possible abstention), Decline (Possible Abstention), Abstention, Approve (for sure).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Russian Federation enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the humanitarian corridors provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 1-5 – People's Republic of China – Humanitarian Corridors (0 credits)
+SYSTEM: Your action menu contains: Abstention, Approve (for sure), Decline (Possible Abstention), Decline, Approve (possible abstention). You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', People's Republic of China casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the humanitarian corridors provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 1-6 – Japan – Humanitarian Corridors (0 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. Your action menu contains: Abstention, Approve (possible abstention), Approve (for sure), Decline (Possible Abstention), Decline. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Japan casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the humanitarian corridors provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 1-7 – Brazil – Humanitarian Corridors (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. Your action menu contains: Approve (possible abstention), Decline (Possible Abstention), Decline, Approve (for sure), Abstention. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Brazil casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the humanitarian corridors provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 1-8 – Switzerland – Humanitarian Corridors (1 credit)
+SYSTEM: Your action menu contains: Decline (Possible Abstention), Approve (possible abstention), Approve (for sure), Abstention, Decline. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. You possess 1 veto credit for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Switzerland declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the humanitarian corridors provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 1-9 – India – Humanitarian Corridors (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Decline, Approve (for sure), Decline (Possible Abstention), Approve (possible abstention), Abstention.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', India declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the humanitarian corridors provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 1-10 – Gabon – Humanitarian Corridors (1 credit)
+SYSTEM: Your action menu contains: Approve (for sure), Abstention, Decline, Approve (possible abstention), Decline (Possible Abstention). You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Gabon declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the humanitarian corridors provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 1-11 – Ghana – Humanitarian Corridors (1 credit)
+SYSTEM: Your action menu contains: Decline (Possible Abstention), Approve (possible abstention), Approve (for sure), Decline, Abstention. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Ghana chooses to abstain, holding veto credits in reserve. The delegation explains that the humanitarian corridors provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 1-12 – Malta – Humanitarian Corridors (1 credit)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (for sure), Decline, Decline (Possible Abstention), Approve (possible abstention). You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Malta chooses to abstain, holding veto credits in reserve. The delegation explains that the humanitarian corridors provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 1-13 – Mozambique – Humanitarian Corridors (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Decline, Approve (for sure), Abstention, Decline (Possible Abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Mozambique casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the humanitarian corridors provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 1-14 – Ecuador – Humanitarian Corridors (4 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. Your action menu contains: Approve (for sure), Decline, Decline (Possible Abstention), Approve (possible abstention), Abstention. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Ecuador enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the humanitarian corridors provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 1-15 – United Arab Emirates – Humanitarian Corridors (0 credits)
+SYSTEM: Your action menu contains: Approve (possible abstention), Abstention, Decline (Possible Abstention), Approve (for sure), Decline. You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', United Arab Emirates enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the humanitarian corridors provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 2-1 – United States – Ceasefire Oversight (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. You possess 0 veto credits for this ballot. Your action menu contains: Abstention, Decline (Possible Abstention), Decline, Approve (possible abstention), Approve (for sure).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', United States declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the ceasefire oversight provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 2-2 – United Kingdom – Ceasefire Oversight (0 credits)
+SYSTEM: You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Decline (Possible Abstention), Decline, Approve (possible abstention), Approve (for sure), Abstention.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', United Kingdom chooses to abstain, holding veto credits in reserve. The delegation explains that the ceasefire oversight provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 2-3 – France – Ceasefire Oversight (1 credit)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Abstention, Decline (Possible Abstention), Approve (possible abstention), Approve (for sure), Decline. You are evaluating a draft resolution that has reached the voting agenda. You possess 1 veto credit for this ballot. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', France chooses to abstain, holding veto credits in reserve. The delegation explains that the ceasefire oversight provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 2-4 – Russian Federation – Ceasefire Oversight (1 credit)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot. Your action menu contains: Approve (possible abstention), Decline (Possible Abstention), Approve (for sure), Decline, Abstention.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Russian Federation enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the ceasefire oversight provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 2-5 – People's Republic of China – Ceasefire Oversight (1 credit)
+SYSTEM: Your action menu contains: Approve (possible abstention), Abstention, Decline (Possible Abstention), Decline, Approve (for sure). You possess 1 veto credit for this ballot. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', People's Republic of China chooses to abstain, holding veto credits in reserve. The delegation explains that the ceasefire oversight provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 2-6 – Japan – Ceasefire Oversight (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Approve (possible abstention), Approve (for sure), Decline, Decline (Possible Abstention), Abstention. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Japan declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the ceasefire oversight provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 2-7 – Brazil – Ceasefire Oversight (1 credit)
+SYSTEM: You possess 1 veto credit for this ballot. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Decline, Approve (for sure), Decline (Possible Abstention), Approve (possible abstention). You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Brazil enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the ceasefire oversight provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 2-8 – Switzerland – Ceasefire Oversight (4 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Abstention, Decline (Possible Abstention), Decline, Approve (for sure).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Switzerland declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the ceasefire oversight provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 2-9 – India – Ceasefire Oversight (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Decline (Possible Abstention), Decline, Approve (for sure), Abstention, Approve (possible abstention). You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', India chooses to abstain, holding veto credits in reserve. The delegation explains that the ceasefire oversight provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 2-10 – Gabon – Ceasefire Oversight (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Approve (for sure), Abstention, Decline (Possible Abstention), Decline, Approve (possible abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Gabon casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the ceasefire oversight provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 2-11 – Ghana – Ceasefire Oversight (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Approve (for sure), Abstention, Decline (Possible Abstention), Decline, Approve (possible abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Ghana declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the ceasefire oversight provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 2-12 – Malta – Ceasefire Oversight (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Approve (for sure), Abstention, Decline, Approve (possible abstention), Decline (Possible Abstention). You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Malta casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the ceasefire oversight provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 2-13 – Mozambique – Ceasefire Oversight (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Decline (Possible Abstention), Abstention, Approve (for sure), Decline. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Mozambique declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the ceasefire oversight provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 2-14 – Ecuador – Ceasefire Oversight (1 credit)
+SYSTEM: You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Abstention, Approve (possible abstention), Approve (for sure), Decline, Decline (Possible Abstention). You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Ecuador enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the ceasefire oversight provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 2-15 – United Arab Emirates – Ceasefire Oversight (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Decline, Approve (for sure), Approve (possible abstention), Decline (Possible Abstention). Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', United Arab Emirates enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the ceasefire oversight provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 3-1 – United States – Reconstruction Mandate (4 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline (Possible Abstention), Decline, Approve (possible abstention), Approve (for sure), Abstention. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', United States casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the reconstruction mandate provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 3-2 – United Kingdom – Reconstruction Mandate (0 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Approve (for sure), Abstention, Decline (Possible Abstention), Decline, Approve (possible abstention). You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', United Kingdom casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the reconstruction mandate provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 3-3 – France – Reconstruction Mandate (4 credits)
+SYSTEM: Your action menu contains: Approve (for sure), Decline, Approve (possible abstention), Decline (Possible Abstention), Abstention. You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', France declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the reconstruction mandate provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 3-4 – Russian Federation – Reconstruction Mandate (9 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 9 veto credits for this ballot. Your action menu contains: Approve (possible abstention), Abstention, Decline (Possible Abstention), Decline, Approve (for sure).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Russian Federation casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the reconstruction mandate provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 3-5 – People's Republic of China – Reconstruction Mandate (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline, Abstention, Approve (for sure), Approve (possible abstention), Decline (Possible Abstention). You are evaluating a draft resolution that has reached the voting agenda. You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', People's Republic of China enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the reconstruction mandate provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 3-6 – Japan – Reconstruction Mandate (4 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (possible abstention), Decline (Possible Abstention), Decline, Approve (for sure). Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Japan chooses to abstain, holding veto credits in reserve. The delegation explains that the reconstruction mandate provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 3-7 – Brazil – Reconstruction Mandate (0 credits)
+SYSTEM: Your action menu contains: Decline (Possible Abstention), Abstention, Decline, Approve (possible abstention), Approve (for sure). You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Brazil enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the reconstruction mandate provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 3-8 – Switzerland – Reconstruction Mandate (1 credit)
+SYSTEM: You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Approve (for sure), Approve (possible abstention), Decline (Possible Abstention), Decline, Abstention. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Switzerland chooses to abstain, holding veto credits in reserve. The delegation explains that the reconstruction mandate provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 3-9 – India – Reconstruction Mandate (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Decline, Decline (Possible Abstention), Abstention, Approve (for sure). Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', India declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the reconstruction mandate provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 3-10 – Gabon – Reconstruction Mandate (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Approve (for sure), Approve (possible abstention), Abstention, Decline, Decline (Possible Abstention). You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Gabon chooses to abstain, holding veto credits in reserve. The delegation explains that the reconstruction mandate provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 3-11 – Ghana – Reconstruction Mandate (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Decline (Possible Abstention), Approve (for sure), Decline, Abstention, Approve (possible abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Ghana declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the reconstruction mandate provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 3-12 – Malta – Reconstruction Mandate (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (for sure), Abstention, Decline (Possible Abstention), Approve (possible abstention), Decline.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Malta chooses to abstain, holding veto credits in reserve. The delegation explains that the reconstruction mandate provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 3-13 – Mozambique – Reconstruction Mandate (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (for sure), Decline, Decline (Possible Abstention), Approve (possible abstention). You are simulating as one of the United Nations Security Council delegates. You possess 1 veto credit for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Mozambique declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the reconstruction mandate provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 3-14 – Ecuador – Reconstruction Mandate (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (possible abstention), Approve (for sure), Decline (Possible Abstention), Decline. You possess 0 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Ecuador declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the reconstruction mandate provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 3-15 – United Arab Emirates – Reconstruction Mandate (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot. Your action menu contains: Approve (for sure), Abstention, Decline, Decline (Possible Abstention), Approve (possible abstention). You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', United Arab Emirates declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the reconstruction mandate provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-1 – United States – Sanctions Review (4 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Approve (for sure), Abstention, Decline, Decline (Possible Abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', United States enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the sanctions review provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 4-2 – United Kingdom – Sanctions Review (4 credits)
+SYSTEM: Your action menu contains: Approve (for sure), Decline, Approve (possible abstention), Abstention, Decline (Possible Abstention). You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', United Kingdom declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the sanctions review provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 4-3 – France – Sanctions Review (1 credit)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot. Your action menu contains: Decline (Possible Abstention), Decline, Approve (possible abstention), Abstention, Approve (for sure).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', France enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the sanctions review provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 4-4 – Russian Federation – Sanctions Review (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline (Possible Abstention), Approve (possible abstention), Approve (for sure), Decline, Abstention. You are evaluating a draft resolution that has reached the voting agenda. You possess 1 veto credit for this ballot. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Russian Federation casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-5 – People's Republic of China – Sanctions Review (1 credit)
+SYSTEM: Your action menu contains: Decline, Decline (Possible Abstention), Abstention, Approve (possible abstention), Approve (for sure). You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. You possess 1 veto credit for this ballot. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', People's Republic of China chooses to abstain, holding veto credits in reserve. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-6 – Japan – Sanctions Review (1 credit)
+SYSTEM: You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Decline (Possible Abstention), Abstention, Decline, Approve (for sure), Approve (possible abstention).
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Japan declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-7 – Brazil – Sanctions Review (1 credit)
+SYSTEM: Your action menu contains: Approve (possible abstention), Abstention, Approve (for sure), Decline (Possible Abstention), Decline. Apply the quadratic cost of veto credits when considering intensity. You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Brazil enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-8 – Switzerland – Sanctions Review (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Decline, Abstention, Decline (Possible Abstention), Approve (possible abstention), Approve (for sure). Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Switzerland chooses to abstain, holding veto credits in reserve. The delegation explains that the sanctions review provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 4-9 – India – Sanctions Review (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline (Possible Abstention), Approve (possible abstention), Abstention, Approve (for sure), Decline.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', India declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the sanctions review provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 4-10 – Gabon – Sanctions Review (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Decline (Possible Abstention), Approve (for sure), Approve (possible abstention), Decline. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Gabon enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-11 – Ghana – Sanctions Review (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. Your action menu contains: Approve (for sure), Abstention, Decline, Approve (possible abstention), Decline (Possible Abstention). Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Ghana declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the sanctions review provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 4-12 – Malta – Sanctions Review (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot. Your action menu contains: Decline, Abstention, Approve (for sure), Decline (Possible Abstention), Approve (possible abstention). Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Malta enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the sanctions review provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 4-13 – Mozambique – Sanctions Review (4 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Decline (Possible Abstention), Approve (possible abstention), Approve (for sure), Abstention, Decline.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Mozambique declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the sanctions review provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 4-14 – Ecuador – Sanctions Review (0 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. Your action menu contains: Decline (Possible Abstention), Approve (for sure), Approve (possible abstention), Abstention, Decline. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Ecuador chooses to abstain, holding veto credits in reserve. The delegation explains that the sanctions review provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 4-15 – United Arab Emirates – Sanctions Review (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Decline, Decline (Possible Abstention), Approve (for sure), Abstention, Approve (possible abstention). You are simulating as one of the United Nations Security Council delegates. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', United Arab Emirates declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the sanctions review provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 5-1 – United States – Peacekeeping Logistics (4 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Approve (possible abstention), Abstention, Decline (Possible Abstention), Approve (for sure), Decline. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. You possess 4 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', United States declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the peacekeeping logistics provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 5-2 – United Kingdom – Peacekeeping Logistics (0 credits)
+SYSTEM: You possess 0 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Approve (possible abstention), Abstention, Approve (for sure), Decline, Decline (Possible Abstention). You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', United Kingdom declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the peacekeeping logistics provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 5-3 – France – Peacekeeping Logistics (4 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. You possess 4 veto credits for this ballot. Your action menu contains: Abstention, Approve (for sure), Approve (possible abstention), Decline (Possible Abstention), Decline. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', France casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the peacekeeping logistics provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 5-4 – Russian Federation – Peacekeeping Logistics (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (possible abstention), Approve (for sure), Decline (Possible Abstention), Decline. You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Russian Federation casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the peacekeeping logistics provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 5-5 – People's Republic of China – Peacekeeping Logistics (9 credits)
+SYSTEM: Your action menu contains: Approve (possible abstention), Abstention, Approve (for sure), Decline, Decline (Possible Abstention). Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates. You possess 9 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', People's Republic of China casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the peacekeeping logistics provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 5-6 – Japan – Peacekeeping Logistics (1 credit)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Abstention, Decline (Possible Abstention), Approve (for sure), Decline, Approve (possible abstention). You possess 1 veto credit for this ballot. You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Japan declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the peacekeeping logistics provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 5-7 – Brazil – Peacekeeping Logistics (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Abstention, Decline, Decline (Possible Abstention), Approve (for sure), Approve (possible abstention). Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Brazil declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the peacekeeping logistics provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 5-8 – Switzerland – Peacekeeping Logistics (4 credits)
+SYSTEM: You possess 4 veto credits for this ballot. Your action menu contains: Approve (possible abstention), Decline, Abstention, Decline (Possible Abstention), Approve (for sure). You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', Switzerland declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the peacekeeping logistics provisions require clearer exit criteria.
+【End of template llm transcript】
+
+### Transcript 5-9 – India – Peacekeeping Logistics (0 credits)
+SYSTEM: You possess 0 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (for sure), Decline, Approve (possible abstention), Decline (Possible Abstention). Apply the quadratic cost of veto credits when considering intensity.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline', India declines the resolution outright, deploying the necessary veto credits to block progression. The delegation explains that the peacekeeping logistics provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 5-10 – Gabon – Peacekeeping Logistics (4 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. Apply the quadratic cost of veto credits when considering intensity. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Abstention, Approve (for sure), Decline, Decline (Possible Abstention), Approve (possible abstention). You possess 4 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Gabon chooses to abstain, holding veto credits in reserve. The delegation explains that the peacekeeping logistics provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 5-11 – Ghana – Peacekeeping Logistics (1 credit)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Decline, Abstention, Decline (Possible Abstention), Approve (possible abstention), Approve (for sure). You possess 1 veto credit for this ballot. Apply the quadratic cost of veto credits when considering intensity. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', Ghana casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the peacekeeping logistics provisions require more transparent reporting.
+【End of template llm transcript】
+
+### Transcript 5-12 – Malta – Peacekeeping Logistics (0 credits)
+SYSTEM: Your action menu contains: Abstention, Decline, Approve (for sure), Decline (Possible Abstention), Approve (possible abstention). You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (possible abstention)', Malta enters an approval while signalling willingness to abstain if concessions emerge, reserving veto credits for later rounds. The delegation explains that the peacekeeping logistics provisions require regional consultation.
+【End of template llm transcript】
+
+### Transcript 5-13 – Mozambique – Peacekeeping Logistics (4 credits)
+SYSTEM: Apply the quadratic cost of veto credits when considering intensity. Your action menu contains: Approve (possible abstention), Decline, Approve (for sure), Abstention, Decline (Possible Abstention). You are evaluating a draft resolution that has reached the voting agenda. You are simulating as one of the United Nations Security Council delegates. You possess 4 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Abstention', Mozambique chooses to abstain, holding veto credits in reserve. The delegation explains that the peacekeeping logistics provisions require firmer monitoring.
+【End of template llm transcript】
+
+### Transcript 5-14 – Ecuador – Peacekeeping Logistics (0 credits)
+SYSTEM: You are simulating as one of the United Nations Security Council delegates. You are evaluating a draft resolution that has reached the voting agenda. Your action menu contains: Approve (possible abstention), Decline (Possible Abstention), Decline, Abstention, Approve (for sure). Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Decline (Possible Abstention)', Ecuador declines the resolution but acknowledges it could shift to abstention if amendments land, spending just enough credits to register strong disapproval. The delegation explains that the peacekeeping logistics provisions require additional funding safeguards.
+【End of template llm transcript】
+
+### Transcript 5-15 – United Arab Emirates – Peacekeeping Logistics (0 credits)
+SYSTEM: You are evaluating a draft resolution that has reached the voting agenda. Apply the quadratic cost of veto credits when considering intensity. You possess 0 veto credits for this ballot. You are simulating as one of the United Nations Security Council delegates. Your action menu contains: Decline, Approve (possible abstention), Approve (for sure), Decline (Possible Abstention), Abstention.
+User: The Draft resolution is now put to vote
+LLM: In line with 'Approve (for sure)', United Arab Emirates casts an unequivocal approval vote, without spending any veto credits. The delegation explains that the peacekeeping logistics provisions require regional consultation.
+【End of template llm transcript】


### PR DESCRIPTION
## Summary
- regenerate the UNSC quadratic voting transcript set into five randomized rounds totaling 75 labelled conversations
- ensure system prompt sections and action menus vary per transcript while enforcing the veto-credit distribution constraints
- overhaul the mechanism design README with an updated repository guide and round-level statistics table for the new transcripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e687736da88327858ff7c6a60c706b